### PR TITLE
New constructors in SyncOkHttpApnsClient to allow customizing the OkHttp clients

### DIFF
--- a/src/main/java/com/clevertap/apns/clients/AsyncOkHttpApnsClient.java
+++ b/src/main/java/com/clevertap/apns/clients/AsyncOkHttpApnsClient.java
@@ -60,6 +60,18 @@ public class AsyncOkHttpApnsClient extends SyncOkHttpApnsClient {
         super(certificate, password, production, defaultTopic, connectionPool);
     }
 
+    public AsyncOkHttpApnsClient(String apnsAuthKey, String teamID, String keyID,
+                                 boolean production, String defaultTopic, OkHttpClient.Builder builder) {
+        super(apnsAuthKey, teamID, keyID, production, defaultTopic, builder);
+    }
+
+    public AsyncOkHttpApnsClient(InputStream certificate, String password, boolean production,
+                                 String defaultTopic, OkHttpClient.Builder builder)
+            throws CertificateException, NoSuchAlgorithmException, KeyStoreException,
+            IOException, UnrecoverableKeyException, KeyManagementException {
+        super(certificate, password, production, defaultTopic, builder);
+    }
+
     @Override
     public NotificationResponse push(Notification notification) {
         throw new UnsupportedOperationException("Synchronous requests are not supported by this client");

--- a/src/main/java/com/clevertap/apns/clients/SyncOkHttpApnsClient.java
+++ b/src/main/java/com/clevertap/apns/clients/SyncOkHttpApnsClient.java
@@ -96,7 +96,7 @@ public class SyncOkHttpApnsClient implements ApnsClient {
     public SyncOkHttpApnsClient(String apnsAuthKey, String teamID, String keyID, boolean production,
                                 String defaultTopic, ConnectionPool connectionPool) {
 		
-        this(apnsAuthKey, teamID, keyID, production, defaultTopic, createDefaultBuilder(connectionPool));
+        this(apnsAuthKey, teamID, keyID, production, defaultTopic, getBuilder(connectionPool));
     }
 
     /**
@@ -157,7 +157,7 @@ public class SyncOkHttpApnsClient implements ApnsClient {
             throws CertificateException, NoSuchAlgorithmException, KeyStoreException,
             IOException, UnrecoverableKeyException, KeyManagementException {
 		
-		this(certificate, password, production, defaultTopic, createDefaultBuilder(connectionPool));
+		this(certificate, password, production, defaultTopic, getBuilder(connectionPool));
 	}
 	
 	/**
@@ -167,15 +167,11 @@ public class SyncOkHttpApnsClient implements ApnsClient {
      * @param connectionPool A connection pool to use. If null, a new one will be generated
 	 * @return a new OkHttp client builder, intialized with default settings.
 	 */
-    public static OkHttpClient.Builder createDefaultBuilder(ConnectionPool connectionPool) {
-        OkHttpClient.Builder builder = new OkHttpClient.Builder();
-
-        builder.connectTimeout(10, TimeUnit.SECONDS)
-                .writeTimeout(10, TimeUnit.SECONDS)
-                .readTimeout(30, TimeUnit.SECONDS);
-
-        connectionPool = connectionPool == null ? new ConnectionPool(10, 10, TimeUnit.MINUTES) : connectionPool;
-        builder.connectionPool(connectionPool);
+    private static OkHttpClient.Builder getBuilder(ConnectionPool connectionPool) {
+        OkHttpClient.Builder builder = ApnsClientBuilder.createDefaultOkHttpClientBuilder();
+		if(connectionPool != null) {
+			builder.connectionPool(connectionPool);
+		}
 
         return builder;
     }


### PR DESCRIPTION
* Added two new constructors that take a OkHttpClient.Builder instance,
  which allow for custom configured HTTP clients
* Renamed 'getBuilder()' method to 'createDefaultBuilder()' and made it
  public, so it can serve as starting point for new builders that
  are then customized and passed to the new constructors
Note that these changes could also be made to AsyncOkHttpApnsClient in a similar fashion to allow customizing that as well.