### PR TITLE
Add support for local APNS mock deployment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.clevertap.apns</groupId>
     <artifactId>apns-http2</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
 
     <name>apns-http2</name>
     <description>A library for communicating with the Apple Push Gateway in HTTP/2.</description>

--- a/src/main/java/com/clevertap/apns/clients/ApnsClientBuilder.java
+++ b/src/main/java/com/clevertap/apns/clients/ApnsClientBuilder.java
@@ -50,6 +50,10 @@ import java.util.concurrent.TimeUnit;
 public class ApnsClientBuilder {
     private InputStream certificate;
     private boolean production;
+    /**
+     * gateway field should be filled for development purposes only, and contain the address of local APNS mock instance.
+     */
+    private String customGateway;
     private String password;
     private int connectionPort = 443;
 
@@ -138,18 +142,25 @@ public class ApnsClientBuilder {
         return this;
     }
 
+    public ApnsClientBuilder withCustomGateway(String customGateway) {
+        this.customGateway = customGateway;
+        this.production = false;
+        return this;
+    }
+
     public ApnsClientBuilder withProductionGateway() {
+        this.customGateway = null;
         this.production = true;
         return this;
     }
 
     public ApnsClientBuilder withProductionGateway(boolean production) {
         if (production) return withProductionGateway();
-
         return withDevelopmentGateway();
     }
 
     public ApnsClientBuilder withDevelopmentGateway() {
+        this.customGateway = null;
         this.production = false;
         return this;
     }
@@ -183,15 +194,31 @@ public class ApnsClientBuilder {
 
         if (certificate != null) {
             if (asynchronous) {
-                return new AsyncOkHttpApnsClient(certificate, password, production, defaultTopic, builder, connectionPort);
+                if (customGateway != null){
+                    return new AsyncOkHttpApnsClient(certificate, password, customGateway, defaultTopic, builder, connectionPort);
+                } else {
+                    return new AsyncOkHttpApnsClient(certificate, password, production, defaultTopic, builder, connectionPort);
+                }
             } else {
-                return new SyncOkHttpApnsClient(certificate, password, production, defaultTopic, builder, connectionPort);
+                if (customGateway != null){
+                    return new SyncOkHttpApnsClient(certificate, password, customGateway, defaultTopic, builder, connectionPort);
+                } else {
+                    return new SyncOkHttpApnsClient(certificate, password, production, defaultTopic, builder, connectionPort);
+                }
             }
         } else if (keyID != null && teamID != null && apnsAuthKey != null) {
             if (asynchronous) {
-                return new AsyncOkHttpApnsClient(apnsAuthKey, teamID, keyID, production, defaultTopic, builder, connectionPort);
+                if (customGateway != null) {
+                    return new AsyncOkHttpApnsClient(apnsAuthKey, teamID, keyID, customGateway, defaultTopic, builder, connectionPort);
+                } else {
+                    return new AsyncOkHttpApnsClient(apnsAuthKey, teamID, keyID, production, defaultTopic, builder, connectionPort);
+                }
             } else {
-                return new SyncOkHttpApnsClient(apnsAuthKey, teamID, keyID, production, defaultTopic, builder, connectionPort);
+                if (customGateway != null) {
+                    return new SyncOkHttpApnsClient(apnsAuthKey, teamID, keyID, customGateway, defaultTopic, builder, connectionPort);
+                } else {
+                    return new SyncOkHttpApnsClient(apnsAuthKey, teamID, keyID, production, defaultTopic, builder, connectionPort);
+                }
             }
         } else {
             throw new IllegalArgumentException("Either the token credentials (team ID, key ID, and the private key) " +

--- a/src/main/java/com/clevertap/apns/clients/AsyncOkHttpApnsClient.java
+++ b/src/main/java/com/clevertap/apns/clients/AsyncOkHttpApnsClient.java
@@ -60,6 +60,13 @@ public class AsyncOkHttpApnsClient extends SyncOkHttpApnsClient {
         super(certificate, password, production, defaultTopic, connectionPool);
     }
 
+    public AsyncOkHttpApnsClient(InputStream certificate, String password, String gateway,
+                                 String defaultTopic, OkHttpClient.Builder builder, int connectionPort)
+            throws CertificateException, NoSuchAlgorithmException, KeyStoreException,
+            IOException, UnrecoverableKeyException, KeyManagementException {
+        super(certificate, password, gateway, defaultTopic, builder, connectionPort);
+    }
+
     public AsyncOkHttpApnsClient(String apnsAuthKey, String teamID, String keyID,
                                  boolean production, String defaultTopic, OkHttpClient.Builder builder) {
         this(apnsAuthKey, teamID, keyID, production, defaultTopic, builder, 443);
@@ -68,6 +75,11 @@ public class AsyncOkHttpApnsClient extends SyncOkHttpApnsClient {
     public AsyncOkHttpApnsClient(String apnsAuthKey, String teamID, String keyID,
                                  boolean production, String defaultTopic, OkHttpClient.Builder builder, int connectionPort) {
         super(apnsAuthKey, teamID, keyID, production, defaultTopic, builder);
+    }
+
+    public AsyncOkHttpApnsClient(String apnsAuthKey, String teamID, String keyID, String gateway,
+                                 String defaultTopic, OkHttpClient.Builder builder, int connectionPort) {
+        super(apnsAuthKey, teamID, keyID, gateway, defaultTopic, builder, connectionPort);
     }
 
     public AsyncOkHttpApnsClient(InputStream certificate, String password, boolean production,


### PR DESCRIPTION
This PR is adding possibility to connect to mock instances of APNS using custom endpoint setting.
If custom endpoint is chosen, certificate will not be validated for Apple-connected strings, and address from constants will be overridden with the one chosen by developer.