### PR TITLE
Token iat change only every 30 minutes for TooManyProviderTokenUpdates

### DIFF
--- a/src/main/java/com/clevertap/apns/clients/SyncOkHttpApnsClient.java
+++ b/src/main/java/com/clevertap/apns/clients/SyncOkHttpApnsClient.java
@@ -286,9 +286,9 @@ public class SyncOkHttpApnsClient implements ApnsClient {
         if (keyID != null && teamID != null && apnsAuthKey != null) {
 
             // Generate a new JWT token if it's null, or older than 55 minutes
-            if (cachedJWTToken == null || System.currentTimeMillis() - lastJWTTokenTS > 55 * 60 * 1000) {
+            if (cachedJWTToken == null || System.currentTimeMillis() / 1000 - lastJWTTokenTS > 55 * 60) {
                 try {
-                    lastJWTTokenTS = System.currentTimeMillis();
+                    lastJWTTokenTS = System.currentTimeMillis() / 1000 / 1800 * 1800;
                     cachedJWTToken = JWT.getToken(teamID, keyID, apnsAuthKey);
                 } catch (InvalidKeySpecException | NoSuchAlgorithmException | SignatureException | InvalidKeyException e) {
                     return null;

--- a/src/main/java/com/clevertap/apns/internal/JWT.java
+++ b/src/main/java/com/clevertap/apns/internal/JWT.java
@@ -54,7 +54,7 @@ public final class JWT {
      */
     public static String getToken(final String teamID, final String keyID, final String secret)
             throws InvalidKeySpecException, NoSuchAlgorithmException, InvalidKeyException, SignatureException {
-        final int now = (int) (System.currentTimeMillis() / 1000);
+        final int now = (int) (System.currentTimeMillis() / 1000 / 1800 * 1800);
         final String header = "{\"alg\":\"ES256\",\"kid\":\"" + keyID + "\"}";
         final String payload = "{\"iss\":\"" + teamID + "\",\"iat\":" + now + "}";
 


### PR DESCRIPTION
Token's iat should be updated lower frequency for preventing TooManyProviderTokenUpdates by distributed system.
I just round up iat by 30 minutes. it may be simplest, and current interface is unchanged.

Timeout is one hours.
https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/establishing_a_token_based_connection_to_apns
> If the value in the iat field is more than one hour old, APNs rejects any notifications containing the token, returning an ExpiredProviderToken (403) error.

once per 20 minutes is limit.
https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns
> 429 | TooManyProviderTokenUpdates | The provider’s authentication token is being updated too often. Update the authentication token no more than once every 20 minutes.