### PR TITLE
Bugfix/also set key managers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,13 +16,13 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.7.0</version>
+            <version>2.9.8</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.1.4</version>
+            <version>2.9.8</version>
         </dependency>
 
         <dependency>
@@ -34,13 +34,13 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>3.10.0</version>
+            <version>3.14.1</version>
         </dependency>
 
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>3.2.0</version>
+            <version>3.10.0</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.clevertap.apns</groupId>
     <artifactId>apns-http2</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
 
     <name>apns-http2</name>
     <description>A library for communicating with the Apple Push Gateway in HTTP/2.</description>

--- a/src/main/java/com/clevertap/apns/clients/SyncOkHttpApnsClient.java
+++ b/src/main/java/com/clevertap/apns/clients/SyncOkHttpApnsClient.java
@@ -178,7 +178,7 @@ public class SyncOkHttpApnsClient implements ApnsClient {
         SSLContext sslContext = SSLContext.getInstance("TLS");
 
         final TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-        tmf.init((KeyStore) null);
+        tmf.init(ks);
         sslContext.init(keyManagers, tmf.getTrustManagers(), null);
 
         final SSLSocketFactory sslSocketFactory = sslContext.getSocketFactory();

--- a/src/main/java/com/clevertap/apns/clients/SyncOkHttpApnsClient.java
+++ b/src/main/java/com/clevertap/apns/clients/SyncOkHttpApnsClient.java
@@ -190,7 +190,7 @@ public class SyncOkHttpApnsClient implements ApnsClient {
             throw new IllegalStateException("Unexpected default trust managers:" + Arrays.toString(trustManagers));
         }
         X509TrustManager trustManager = (X509TrustManager) trustManagers[0];
-        sslContext.init(null, new TrustManager[]{trustManager}, null);
+        sslContext.init(keyManagers, new TrustManager[]{trustManager}, null);
         builder.sslSocketFactory(sslSocketFactory, trustManager);
 
         client = builder.build();
@@ -317,6 +317,7 @@ public class SyncOkHttpApnsClient implements ApnsClient {
         Response response = null;
 
         try {
+            
             response = client.newCall(request).execute();
             return parseResponse(response);
         } catch (Throwable t) {

--- a/src/test/com/clevertap/apns/integration/NotificationTest.java
+++ b/src/test/com/clevertap/apns/integration/NotificationTest.java
@@ -1,0 +1,60 @@
+package com.clevertap.apns.integration;
+
+import com.clevertap.apns.ApnsClient;
+import com.clevertap.apns.Notification;
+import com.clevertap.apns.NotificationResponse;
+import com.clevertap.apns.NotificationResponseListener;
+import com.clevertap.apns.clients.ApnsClientBuilder;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
+
+public class NotificationTest {
+    private static String APN_AUTH_KEY;
+    private static String TOKEN;
+    private static String TEAM_ID;
+    private static String KEY_ID;
+
+    ApnsClient asyncClient;
+    @BeforeClass
+    public static void init(){
+        APN_AUTH_KEY = System.getProperty("com.clevertap.auth_key");
+        TOKEN = System.getProperty("com.clevertap.token");
+        TEAM_ID = System.getProperty("com.clevertap.team_id");
+        KEY_ID = System.getProperty("com.clevertap.key_id");
+    }
+    @Before
+    public void setUp() throws CertificateException, UnrecoverableKeyException, NoSuchAlgorithmException, KeyStoreException, KeyManagementException, IOException {
+        asyncClient = new ApnsClientBuilder().
+                inAsynchronousMode().
+                withApnsAuthKey(APN_AUTH_KEY).
+                withTeamID(TEAM_ID).
+                withKeyID(KEY_ID).
+                build();
+    }
+    @Test
+    public void sendNotification(){
+        Notification notification = new Notification.Builder(TOKEN).alertBody("Hello").build();
+
+        asyncClient.push(notification, new NotificationResponseListener() {
+            @Override
+            public void onSuccess(Notification notification) {
+
+            }
+
+            @Override
+            public void onFailure(Notification notification, NotificationResponse response) {
+                Assert.fail("Failed to send notification: "+response.getResponseBody());
+            }
+        });
+    }
+
+}


### PR DESCRIPTION
Using the jdk-9 branch I discovered that one also needs to set the key managers so mutual TLS auth actually works (which makes sense, because the client also needs to provide it's client key, not only the cert).

I also took the liberty of updating all the dependencies to modern versions, since some contain bugs for jdk/jre-11, which I am running this on.