### PR TITLE
Add "url-args" for Safari web push

### DIFF
--- a/src/main/java/com/clevertap/apns/Notification.java
+++ b/src/main/java/com/clevertap/apns/Notification.java
@@ -208,6 +208,11 @@ public class Notification {
             return this;
         }
 
+        public Builder urlArgs(String[] args) {
+            aps.put("url-args", args);
+            return this;
+        }
+
         public Builder sound(String sound) {
             if (sound != null) {
                 aps.put("sound", sound);


### PR DESCRIPTION
url-args is a mandatory argument needed in Safari web push payload