### PR TITLE
fixes compatibility with jdk 9+ and jdk8u252+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>3.2.0</version>
+            <version>4.8.1</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/clevertap/apns/clients/SyncOkHttpApnsClient.java
+++ b/src/main/java/com/clevertap/apns/clients/SyncOkHttpApnsClient.java
@@ -43,6 +43,7 @@ import java.security.*;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.security.spec.InvalidKeySpecException;
+import java.util.Arrays;
 import java.util.UUID;
 
 /**
@@ -180,9 +181,14 @@ public class SyncOkHttpApnsClient implements ApnsClient {
         tmf.init((KeyStore) null);
         sslContext.init(keyManagers, tmf.getTrustManagers(), null);
 
+        TrustManager[] trustManagers = tmf.getTrustManagers();
+        if (trustManagers.length != 1 || !(trustManagers[0] instanceof X509TrustManager)) {
+            throw new IllegalStateException("Unexpected default trust managers:" + Arrays.toString(trustManagers));
+        }
+
         final SSLSocketFactory sslSocketFactory = sslContext.getSocketFactory();
 
-        builder.sslSocketFactory(sslSocketFactory);
+        builder.sslSocketFactory(sslSocketFactory, (X509TrustManager) trustManagers[0]);
 
         client = builder.build();
 


### PR DESCRIPTION
#44 

I attached a pull request which works with client certificate authentication. @aclowkey s version didn't work together with client certificates.